### PR TITLE
Remove fully generic type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,7 +107,6 @@ export declare class Component {
   entity: Entity;
   id: string;
   update(values?: IComponentUpdate): void;
-  [name: string]: any;
 }
 
 // an object that has strings as keys and strings as values


### PR DESCRIPTION
Setting `[name: string]: any;` effectively makes type checking pointless, since it causes the compiler to recognize any property used in any way to be considered valid. Switching this off will properly show type errors when attempting to access properties that have not been defined on a component.