### PR TITLE
Fix typing of World.systems

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -268,7 +268,7 @@ export declare class World {
   createQuery(init?: IQueryConfig): Query;
 
   // Allows passing of a class that extends System, or an instance of such a class
-  registerSystem<T extends typeof System>(group: string, system: T|System): any;
+  registerSystem<T extends System>(group: string, system: T | (new(world: World) => T)): T;
 
   runSystems(group: string): void;
   updateIndexes(): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -247,7 +247,7 @@ export declare class World {
   componentTypes: IEntityComponents;
   queries: Query[];
   subscriptions: Map<string, System>;
-  systems: Map<string, System>;
+  systems: Map<string, Set<System>>;
   tick(): number;
   registerTags(...tags: string[]): void;
 


### PR DESCRIPTION
Unless I'm reading this wrong, it seems like `world.systems` is actually a Map of group names to Sets of Systems:
https://github.com/fritzy/ape-ecs/blob/master/src/world.js#L345

Also added a proper return type for `registerSystem`, instead of using `any`.