### PR TITLE
add shorthand for name of system, change initArgs type to unknown[]

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ export interface IQueryConfig {
 }
 
 export declare class System {
+  get sysName(): string;
   constructor(world: World, ...initArgs: any[]);
   world: World;
   changes: IComponentChange[];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,13 +30,13 @@ export interface IQueryConfig {
 
 export declare class System {
   get sysName(): string;
-  constructor(world: World, ...initArgs: any[]);
+  constructor(world: World, ...initArgs: unknown[]);
   world: World;
   changes: IComponentChange[];
   queries: Query[];
   lastTick: number;
   static subscriptions: string[];
-  init(...initArgs: any[]): void;
+  init(...initArgs: unknown[]): void;
   update(tick: number): void;
   createQuery(init?: IQueryConfig): Query;
   subscribe(type: string | ComponentClass): void;

--- a/src/system.js
+++ b/src/system.js
@@ -1,6 +1,11 @@
 const Query = require('./query');
 
 class System {
+
+  get sysName() {
+    return this.constructor.name;
+  }
+
   constructor(world, ...initArgs) {
     this.world = world;
     this._stagedChanges = [];


### PR DESCRIPTION
`unknown` is the better choice if the type-safety should be kept intact, but the arguments are *unknown* 
-> https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#new-unknown-top-type

The `sysName` is a shortcut which I introduced to save me from typing `this.constructor.name` within my log messages all the time.