### PR TITLE
Typesafe API for defining Components and creating Entities

### DIFF
--- a/docs/Component.md
+++ b/docs/Component.md
@@ -295,3 +295,22 @@ Position.properties = {
   coord: '0x0'
 };
  ```
+
+# TypedComponent
+
+There's an additional API for creating typed Components, which have typed `.properties` defined for the Component class and fields of those types on the instances. This uses the mixin pattern in TypeScript.
+
+To create a `TypedComponent`:
+
+```ts
+class Position extends ApeECS.TypedComponent({x: 0, y: 0}) {};
+```
+
+This creates a `Position` class with `typeof properties === {x: number, y: number}`.
+A `TypedComponent` can have `properties` typed as a superset of the initial properties. For example:
+
+```ts
+class Position extends ApeECS.TypedComponent<{x: number, y?: number}>({x: 0}) {};
+```
+
+These types are used in the [world.createEntityTypesafe](./World.md#createEntityTypesafe) API.

--- a/docs/Component.md
+++ b/docs/Component.md
@@ -306,11 +306,11 @@ To create a `TypedComponent`:
 class Position extends ApeECS.TypedComponent({x: 0, y: 0}) {};
 ```
 
-This creates a `Position` class with `typeof properties === {x: number, y: number}`.
+This creates a `Position` class with properties typed `{x: number, y: number}`.
 A `TypedComponent` can have `properties` typed as a superset of the initial properties. For example:
 
 ```ts
 class Position extends ApeECS.TypedComponent<{x: number, y?: number}>({x: 0}) {};
 ```
 
-These types are used in the [world.createEntityTypesafe](./World.md#createEntityTypesafe) API.
+These types are used in the [world.createEntityTypesafe](./World.md#createEntityTypesafe) API and [entity.addComponent](./Entity.md#addComponent).

--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -124,6 +124,16 @@ entity.addComponent({
 
 Setting a key makes the `Component` instance accessible as a property of the `Entity`.
 
+👆 Using the api `addComponent({type: Point})` (using the `Point` class rather than a string) will enforce type checking for that component in TypeScript.
+```ts
+entity.addComponent({
+  type: Point,
+  x: 123,
+  y: 'three',
+  // ^ error
+})
+```
+
 💭 It can sometimes be useful to set a custom id for an `Entity`, but there may not be a valid usecase for a new `Component`. You should generally only specify the `id` in `addComponent` if you're restoring a previous `Component` from `getObject`.
 
 👀 See [world.createEntity](./World.md#createEntity) for another perspective on `Component` instance definitions.

--- a/docs/World.md
+++ b/docs/World.md
@@ -220,7 +220,7 @@ class Position extends TypedComponent<{x: number, y?: number}> {};
 class Texture extends TypedComponent<{filePath: string}> {};
 class Flag extends TypedComponent() {};
 
-const playerEntity = world.createEntityTypesafe<[{type: Position}, {type: Texture}]>({
+const playerEntity = world.createEntityTypesafe({
   id: 'Player', // optional
   tags: ['Character', 'Visible'], //optional
   components: [ // optional

--- a/docs/World.md
+++ b/docs/World.md
@@ -212,17 +212,21 @@ const playerEntity = world.createEntity({
 
 ## createEntityTypesafe
 
-Create a new Entity, including its type-checked `Components`. This API is slightly reduced from `createEntity`, in that it does not take `components`, only `c`.
-The `type` of the `Component` is used to check the types of the initial arguments.
+Create a new Entity, including its type-checked `Components`. This API is slightly reduced from `createEntity`, in that it does not `c`.
+The `type` of the `Component` is used to check the types of the initial arguments, and `type` must be a Component class.
 
 ```ts
 class Position extends TypedComponent<{x: number, y?: number}> {};
 class Texture extends TypedComponent<{filePath: string}> {};
+class Flag extends TypedComponent() {};
 
 const playerEntity = world.createEntityTypesafe<[{type: Position}, {type: Texture}]>({
   id: 'Player', // optional
   tags: ['Character', 'Visible'], //optional
-  c: [ // optional
+  components: [ // optional
+    {
+      type: Flag,
+    },
     {
       type: Position,
       x: 15,

--- a/docs/World.md
+++ b/docs/World.md
@@ -219,19 +219,21 @@ The `type` of the `Component` is used to check the types of the initial argument
 class Position extends TypedComponent<{x: number, y?: number}> {};
 class Texture extends TypedComponent<{filePath: string}> {};
 
-const playerEntity = world.createEntityTypesafe({
+const playerEntity = world.createEntityTypesafe<[{type: Position}, {type: Texture}]>({
   id: 'Player', // optional
   tags: ['Character', 'Visible'], //optional
   c: [ // optional
     {
       type: Position,
-      x: 15
+      x: 15,
+      z: 1
+      // ^ errors
     },
     {
       type: Texture,
       filePath: "/assets/img.png",
     }
-  }
+  ]
 });
 ```
 

--- a/docs/World.md
+++ b/docs/World.md
@@ -210,6 +210,31 @@ const playerEntity = world.createEntity({
 
 💭 **Ape ECS** uses a very fast unique id generator for `Components` and `Entities` if you don't specify a given id upon creation. Look at the code in [src/util.js](../src/util.js).
 
+## createEntityTypesafe
+
+Create a new Entity, including its type-checked `Components`. This API is slightly reduced from `createEntity`, in that it does not take `components`, only `c`.
+The `type` of the `Component` is used to check the types of the initial arguments.
+
+```ts
+class Position extends TypedComponent<{x: number, y?: number}> {};
+class Texture extends TypedComponent<{filePath: string}> {};
+
+const playerEntity = world.createEntityTypesafe({
+  id: 'Player', // optional
+  tags: ['Character', 'Visible'], //optional
+  c: [ // optional
+    {
+      type: Position,
+      x: 15
+    },
+    {
+      type: Texture,
+      filePath: "/assets/img.png",
+    }
+  }
+});
+```
+
 ## getObject
 
 Retrieves a serializable object that includes all of the Entities and their Components in the World.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ape-ecs",
       "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
@@ -19,7 +20,7 @@
         "markdown-link-check": "^3.8.3",
         "mocha": "^8.1.2",
         "nyc": "^15.1.0",
-        "prettier": "^2.2.0",
+        "prettier": "^2.3.2",
         "ts-node": "^9.0.0",
         "typescript": "^4.0.2",
         "webpack": "^4.43.0",
@@ -1642,7 +1643,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6463,9 +6463,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
-      "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8522,8 +8522,7 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.0"
@@ -8653,6 +8652,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -9130,7 +9130,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -9176,6 +9175,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -15278,9 +15278,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
-      "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/fritzy/ape-ecs/issues"
   },
   "homepage": "https://github.com/fritzy/ape-ecs#readme",
-  "dependencies": {},
   "devDependencies": {
     "@hapi/eslint-plugin-hapi": "^4.3.5",
     "@types/chai": "^4.2.12",
@@ -42,7 +41,7 @@
     "markdown-link-check": "^3.8.3",
     "mocha": "^8.1.2",
     "nyc": "^15.1.0",
-    "prettier": "^2.2.0",
+    "prettier": "^2.3.2",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2",
     "webpack": "^4.43.0",

--- a/src/entity.js
+++ b/src/entity.js
@@ -99,7 +99,10 @@ class Entity {
   }
 
   addComponent(properties) {
-    const type = properties.type;
+    let type = properties.type;
+    if (typeof type !== 'string') {
+      type = type.name;
+    }
     const pool = this.world.componentPool.get(type);
     if (pool === undefined) {
       throw new Error(`Component "${type}" has not been registered.`);
@@ -163,7 +166,6 @@ class Entity {
   }
 
   destroy() {
-
     if (this.destroyed) return;
     if (this.world.refs[this.id]) {
       for (const ref of this.world.refs[this.id]) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -246,7 +246,7 @@ export interface IEntityConfig {
 export type TypedEntityConfig<TComponents extends readonly any[]> = {
   id?: string;
   tags?: string[];
-  c: {
+  components: {
     [K in keyof TComponents]: TypedComponentConfigVal<TComponents[K]>;
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,18 @@
 const { EntityRef, EntitySet, EntityObject } = require('./entityrefs');
+const Component = require('./component');
+
+function TypedComponent(props) {
+  const typedClass = class TypedComponent extends Component {};
+  typedClass.properties = { ...props };
+  return typedClass;
+}
+
 module.exports = {
   World: require('./world'),
   System: require('./system'),
-  Component: require('./component'),
   Entity: require('./entity'),
+  Component,
+  TypedComponent,
   EntityRef,
   EntitySet,
   EntityObject

--- a/src/world.js
+++ b/src/world.js
@@ -255,6 +255,16 @@ module.exports = class World {
     this.componentPool.set(name, new ComponentPool(this, name, spinup));
   }
 
+  createEntityTypesafe(definition) {
+    definition = {
+      ...definition,
+      c: definition.c.map((c) => {
+        return { ...c, type: c.type.name };
+      })
+    };
+    return this.createEntity(definition);
+  }
+
   createEntity(definition) {
     return this.entityPool.get(definition);
   }

--- a/src/world.js
+++ b/src/world.js
@@ -258,7 +258,7 @@ module.exports = class World {
   createEntityTypesafe(definition) {
     definition = {
       ...definition,
-      c: definition.c.map((c) => {
+      components: definition.components.map((c) => {
         return { ...c, type: c.type.name };
       })
     };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -81,6 +81,13 @@ describe('express components', () => {
     expect(results.size).to.equal(1);
   });
 
+  it('addComponent with type!=string', () => {
+    const e = ecs.createEntity({});
+    e.addComponent({ type: Position, x: 1 });
+    const results = ecs.createQuery().fromAll(Position).execute();
+    expect(results.size).to.equal(2);
+  });
+
   it('entity refs', () => {
     class Storage extends ECS.Component {
       static properties = {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -75,7 +75,7 @@ describe('express components', () => {
 
   it('create typesafe entities', () => {
     ecs.createEntityTypesafe({
-      c: [{ type: Position, x: 1 }]
+      components: [{ type: Position, x: 1 }]
     });
     const results = ecs.createQuery().fromAll(Position).execute();
     expect(results.size).to.equal(1);


### PR DESCRIPTION
Looking for any feedback on this! I'm using it locally for developing a game, and thought it might be useful to others.
Similar to #48 
Fixes #71 

The docs should explain the usage, but basically it allows for:
```ts
class Position extends TypedComponent<{x: number, y?: number}>({x: 0, y: 0}) {};
class Texture extends TypedComponent({filePath: "defaultAsset.png"}) {};

const playerEntity = world.createEntityTypesafe({
  c: [
    {
      type: Position,
      x: 15
    },
    {
      type: Texture,
      filePath: "/assets/img.png",
    }
  }
});
```

It also gives safety in `world.createEntityTypesafe`, where the initial properties are type checked. 